### PR TITLE
Global Terminal buffer with a few helper functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 cross/
 *.o
 src/kernel.bin
+src/start.sh

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@
 cross/
 *.o
 src/kernel.bin
-src/start.sh
-src/osdevbarebones.c

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ cross/
 *.o
 src/kernel.bin
 src/start.sh
+src/osdevbarebones.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -17,3 +17,6 @@ clean:
 
 format:
 	clang-format -i *.c *.h
+
+start:
+	qemu-system-i386 -kernel kernel.bin

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -4,4 +4,5 @@
 void kernel_main(void) {
   term_init();
   term_write("MiniOS Kernel Team #1");
+  term_write("Testing");
 }

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -3,6 +3,8 @@
 
 void kernel_main(void) {
   term_init();
-  term_writeline("MiniOS Kernel Team #1");
-  term_writeline("Testing");
+  term_write("MiniOS Kernel Team #1\n");
+  term_writeline("Testing writeline");
+  term_err("This is an error\n");
+  term_warn("This is a warning\n");
 }

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -3,6 +3,6 @@
 
 void kernel_main(void) {
   term_init();
-  term_write("MiniOS Kernel Team #1");
-  term_write("Testing");
+  term_writeline("MiniOS Kernel Team #1");
+  term_writeline("Testing");
 }

--- a/src/term.c
+++ b/src/term.c
@@ -10,6 +10,11 @@ static size_t strlen(const char *str);
 static const size_t VGA_WIDTH = 80;  // Width of the screen.
 static const size_t VGA_HEIGHT = 25; // Height of the screen.
 
+size_t term_row;
+size_t term_col;
+uint8_t term_color; //unused at the moment
+uint16_t *term_buf;
+
 /* TODO: Rewrite this, I took this off of OSDev, so it needs to be sourced or
  * rewritten. */
 enum vga_color {
@@ -45,12 +50,14 @@ static inline uint16_t vga_entry(unsigned char uc, uint8_t color) {
 
 void term_init() {
   // TODO: Apparently this is deprecated in UEFI.
-  uint16_t *buf = (uint16_t *)0xB8000;
+  term_buf = (uint16_t *)0xB8000;
+  term_row = 0;
+  term_col = 0;
 
   for (size_t y = 0; y < VGA_HEIGHT; y++) {
     for (size_t x = 0; x < VGA_WIDTH; x++) {
       const size_t idx = y * VGA_WIDTH + x;
-      buf[idx] = vga_entry(' ', VGA_COLOR_WHITE);
+      term_buf[idx] = vga_entry(' ', VGA_COLOR_WHITE);
     }
   }
 }
@@ -59,9 +66,8 @@ void term_init() {
 void term_write(const char *s) {
   size_t len = strlen(s);
   // TODO: This is wrong, but it's proof-of-concept at this point. Fix later.
-  uint16_t *buf = (uint16_t *)0xB8000;
   for (size_t i = 0; i < len; i++) {
-    buf[i] = vga_entry(s[i], VGA_COLOR_WHITE);
+    term_buf[i] = vga_entry(s[i], VGA_COLOR_WHITE);
   }
 }
 

--- a/src/term.c
+++ b/src/term.c
@@ -66,9 +66,43 @@ void term_init() {
 void term_write(const char *s) {
   size_t len = strlen(s);
   // TODO: This is wrong, but it's proof-of-concept at this point. Fix later.
+  // for (size_t i = 0; i < len; i++) {
+  //   term_buf[i] = vga_entry(s[i], VGA_COLOR_WHITE);
+  // }
   for (size_t i = 0; i < len; i++) {
-    term_buf[i] = vga_entry(s[i], VGA_COLOR_WHITE);
+    
+    if(++term_col == VGA_WIDTH) {
+      term_row++;
+      term_col = 0;
+    }
+    if(term_row + 1 == VGA_HEIGHT) {
+      // TODO: Add scrolling the terminal up a line
+    }
+
+    size_t term_pos = term_row * VGA_WIDTH + term_col;
+    term_buf[term_pos] = vga_entry(s[i], VGA_COLOR_WHITE);
   }
+}
+
+//Write to the terminal buffer and end with a newline
+//This seems kind of redundent but I added it anyway
+//Feel free to remove
+void term_writeline(const char *s) {
+  size_t len = strlen(s);
+  for (size_t i = 0; i < len; i++) {
+    if(++term_col == VGA_WIDTH) {
+      term_row++;
+      term_col = 0;
+    }
+    if(term_row + 1 == VGA_HEIGHT) {
+      // TODO: Add scrolling the terminal up a line
+    }
+    
+    size_t term_pos = term_row * VGA_WIDTH + term_col;
+    term_buf[term_pos] = vga_entry(s[i], VGA_COLOR_WHITE);
+  }
+  term_col = 0;
+  term_row++;
 }
 
 // Return the size of a string.

--- a/src/term.c
+++ b/src/term.c
@@ -10,10 +10,10 @@ static size_t strlen(const char *str);
 static const size_t VGA_WIDTH = 80;  // Width of the screen.
 static const size_t VGA_HEIGHT = 25; // Height of the screen.
 
-size_t term_row;
-size_t term_col;
-uint8_t term_color; //unused at the moment
-uint16_t *term_buf;
+size_t term_row;    // Current row the terminal is at
+size_t term_col;    // Current column the terminal is at
+uint8_t term_color; // Unused at the moment
+uint16_t *term_buf; // Terminal buffer
 
 /* TODO: Rewrite this, I took this off of OSDev, so it needs to be sourced or
  * rewritten. */
@@ -62,13 +62,9 @@ void term_init() {
   }
 }
 
-// Write out a string to the terminal buffer.
-void term_write(const char *s) {
+void term_write_color(const char *s, const uint8_t color)
+{
   size_t len = strlen(s);
-  // TODO: This is wrong, but it's proof-of-concept at this point. Fix later.
-  // for (size_t i = 0; i < len; i++) {
-  //   term_buf[i] = vga_entry(s[i], VGA_COLOR_WHITE);
-  // }
   for (size_t i = 0; i < len; i++) {
     
     if(++term_col == VGA_WIDTH) {
@@ -79,28 +75,39 @@ void term_write(const char *s) {
       // TODO: Add scrolling the terminal up a line
     }
 
+    if(s[i] == '\n') {
+      term_row++;
+      term_col = 0;
+      continue;
+    }
+
     size_t term_pos = term_row * VGA_WIDTH + term_col;
-    term_buf[term_pos] = vga_entry(s[i], VGA_COLOR_WHITE);
+    term_buf[term_pos] = vga_entry(s[i], color);
   }
+}
+
+// Write out a string to the terminal buffer.
+void term_write(const char *s) {
+  term_write_color(s, VGA_COLOR_WHITE);
+}
+
+// Write an error to the terminal buffer
+// TODO: Anything besides just being red
+void term_err(const char *s) {
+  term_write_color(s, VGA_COLOR_RED);
+}
+
+// Write a warning to the terminal buffer
+void term_warn(const char *s) {
+  //There is no yellow so I picked a random color for now
+  term_write_color(s, VGA_COLOR_MAGENTA);
 }
 
 //Write to the terminal buffer and end with a newline
 //This seems kind of redundent but I added it anyway
 //Feel free to remove
 void term_writeline(const char *s) {
-  size_t len = strlen(s);
-  for (size_t i = 0; i < len; i++) {
-    if(++term_col == VGA_WIDTH) {
-      term_row++;
-      term_col = 0;
-    }
-    if(term_row + 1 == VGA_HEIGHT) {
-      // TODO: Add scrolling the terminal up a line
-    }
-    
-    size_t term_pos = term_row * VGA_WIDTH + term_col;
-    term_buf[term_pos] = vga_entry(s[i], VGA_COLOR_WHITE);
-  }
+  term_write_color(s, VGA_COLOR_WHITE);
   term_col = 0;
   term_row++;
 }

--- a/src/term.c
+++ b/src/term.c
@@ -12,7 +12,6 @@ static const size_t VGA_HEIGHT = 25; // Height of the screen.
 
 size_t term_row;    // Current row the terminal is at
 size_t term_col;    // Current column the terminal is at
-uint8_t term_color; // Unused at the moment
 uint16_t *term_buf; // Terminal buffer
 
 /* TODO: Rewrite this, I took this off of OSDev, so it needs to be sourced or
@@ -62,20 +61,19 @@ void term_init() {
   }
 }
 
-void term_write_color(const char *s, const uint8_t color)
-{
+void term_write_color(const char *s, const uint8_t color) {
   size_t len = strlen(s);
   for (size_t i = 0; i < len; i++) {
-    
-    if(++term_col == VGA_WIDTH) {
+
+    if (++term_col == VGA_WIDTH) {
       term_row++;
       term_col = 0;
     }
-    if(term_row + 1 == VGA_HEIGHT) {
+    if (term_row + 1 == VGA_HEIGHT) {
       // TODO: Add scrolling the terminal up a line
     }
 
-    if(s[i] == '\n') {
+    if (s[i] == '\n') {
       term_row++;
       term_col = 0;
       continue;
@@ -87,25 +85,21 @@ void term_write_color(const char *s, const uint8_t color)
 }
 
 // Write out a string to the terminal buffer.
-void term_write(const char *s) {
-  term_write_color(s, VGA_COLOR_WHITE);
-}
+void term_write(const char *s) { term_write_color(s, VGA_COLOR_WHITE); }
 
 // Write an error to the terminal buffer
 // TODO: Anything besides just being red
-void term_err(const char *s) {
-  term_write_color(s, VGA_COLOR_RED);
-}
+void term_err(const char *s) { term_write_color(s, VGA_COLOR_RED); }
 
 // Write a warning to the terminal buffer
 void term_warn(const char *s) {
-  //There is no yellow so I picked a random color for now
+  // There is no yellow so I picked a random color for now
   term_write_color(s, VGA_COLOR_MAGENTA);
 }
 
-//Write to the terminal buffer and end with a newline
-//This seems kind of redundent but I added it anyway
-//Feel free to remove
+// Write to the terminal buffer and end with a newline
+// This seems kind of redundent but I added it anyway
+// Feel free to remove
 void term_writeline(const char *s) {
   term_write_color(s, VGA_COLOR_WHITE);
   term_col = 0;

--- a/src/term.h
+++ b/src/term.h
@@ -2,6 +2,7 @@
 #define TERM_H
 
 void term_init();
+void term_writeline(const char *s);
 void term_write(const char *s);
 
 #endif // TERM_H

--- a/src/term.h
+++ b/src/term.h
@@ -1,8 +1,13 @@
 #ifndef TERM_H
 #define TERM_H
 
+#include <stdint.h>
+
 void term_init();
+void term_write_color(const char *s, const uint8_t color);
 void term_writeline(const char *s);
 void term_write(const char *s);
+void term_err(const char *s);
+void term_warn(const char *s);
 
 #endif // TERM_H


### PR DESCRIPTION
- Changed over to using a global terminal buffer so text doesn't get overwritten on subsequent term_write calls
- Added term_err and term_warn to display text in red and magenta respectively
- Added term_write_color to display text in any of the supported colors