### PR TITLE
Enable paging - Identity Paging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .git/
+.vscode/
 cross/
 *.o
+/src/build
 src/kernel.bin
 src/kernel.iso

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,7 @@ HDRS=term.h
 
 all: kernel.bin kernel.iso
 
-kernel.bin: gdt.o boot.o kernel.o term.o $(HDRS)
+kernel.bin: paging.o gdt.o boot.o kernel.o term.o $(HDRS)
 	$(CC) -T linker.ld -o $@ -ffreestanding -O2 -nostdlib $^ -lgcc
 
 boot.o: boot.asm

--- a/src/boot.asm
+++ b/src/boot.asm
@@ -69,6 +69,7 @@ _start:
         mov ss, ax
 
         ; Set up identity Page tables
+        ; TODO(Britton): Support non-identity paging
         mov eax, page_tables
         push eax
         mov eax, page_directory
@@ -81,9 +82,6 @@ _start:
         mov eax, cr0
         or eax, 0x80000001
         mov cr0, eax
-        
-        mov ecx, page_tables
-        push ecx 
 
 ; Enter the main kernel.
         extern kernel_main

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -1,69 +1,10 @@
 /** src/kernel.c */
 #include "term.h"
 
-void kernel_main(uint32_t in) {
+void kernel_main() {
   term_init();
   term_write("MiniOS Kernel Team #1\n");
   term_writeline("Testing writeline");
   term_err("This is an error\n");
   term_warn("This is a warning\n");
-
-  // NOTE(Britton): Debug Code
-
-  // Mask to 'and out' the flag bits from page table entry
-  uint32_t mask = ~0xFFF;
-  // Move 'in' to the second page table - addressing second meg of memory
-  in += 4096;
-  // Print the address of page_tables[1]
-  for (int i = 31; i >= 0; i--) {
-    uint32_t x = in & ((uint32_t)1 << i);
-    char c[2] = {'0', 0};
-    c[0] += !!x;
-    term_write(c);
-  }
-  term_write("\n");
-
-  // Check The contents of page_tables[1]
-  // Bit 5 is 'accessed' and bit 6 is 'dirty' - they are both 0
-  for (int i = 31; i >= 0; i--) {
-    uint32_t x = *(uint32_t *)in & ((uint32_t)1 << i);
-    char c[2] = {'0', 0};
-    c[0] += !!x;
-    term_write(c);
-  }
-
-  // Extract the actual pointer from the page table entry
-  uint32_t *ptr = *(uint32_t **)in;
-  ptr = (uint32_t *)((uint32_t)ptr & mask);
-
-  // Check what memory we are addressing
-  term_write("\n");
-  for (int i = 31; i >= 0; i--) {
-    uint32_t x = (uint32_t)ptr & ((uint32_t)1 << i);
-    char c[2] = {'0', 0};
-    c[0] += !!x;
-    term_write(c);
-  }
-  term_write("\n");
-  term_write("\n");
-
-  // Modify the data stored at 1MB
-  *ptr = 0b101010101010;
-  // Recheck contents of page_table[1]
-  // Bits 5 and 6 were set - paging is working
-  for (int i = 31; i >= 0; i--) {
-    uint32_t x = *(uint32_t *)in & ((uint32_t)1 << i);
-    char c[2] = {'0', 0};
-    c[0] += !!x;
-    term_write(c);
-  }
-  term_write("\n");
-  // Check if the memory was actually modified
-  for (int i = 31; i >= 0; i--) {
-    uint32_t x = *ptr & ((uint32_t)1 << i);
-    char c[2] = {'0', 0};
-    c[0] += !!x;
-    term_write(c);
-  }
-  term_write("\n");
 }

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -1,10 +1,69 @@
 /** src/kernel.c */
 #include "term.h"
 
-void kernel_main(void) {
+void kernel_main(uint32_t in) {
   term_init();
   term_write("MiniOS Kernel Team #1\n");
   term_writeline("Testing writeline");
   term_err("This is an error\n");
   term_warn("This is a warning\n");
+
+  // NOTE(Britton): Debug Code
+
+  // Mask to 'and out' the flag bits from page table entry
+  uint32_t mask = ~0xFFF;
+  // Move 'in' to the second page table - addressing second meg of memory
+  in += 4096;
+  // Print the address of page_tables[1]
+  for (int i = 31; i >= 0; i--) {
+    uint32_t x = in & ((uint32_t)1 << i);
+    char c[2] = {'0', 0};
+    c[0] += !!x;
+    term_write(c);
+  }
+  term_write("\n");
+
+  // Check The contents of page_tables[1]
+  // Bit 5 is 'accessed' and bit 6 is 'dirty' - they are both 0
+  for (int i = 31; i >= 0; i--) {
+    uint32_t x = *(uint32_t *)in & ((uint32_t)1 << i);
+    char c[2] = {'0', 0};
+    c[0] += !!x;
+    term_write(c);
+  }
+
+  // Extract the actual pointer from the page table entry
+  uint32_t *ptr = *(uint32_t **)in;
+  ptr = (uint32_t *)((uint32_t)ptr & mask);
+
+  // Check what memory we are addressing
+  term_write("\n");
+  for (int i = 31; i >= 0; i--) {
+    uint32_t x = (uint32_t)ptr & ((uint32_t)1 << i);
+    char c[2] = {'0', 0};
+    c[0] += !!x;
+    term_write(c);
+  }
+  term_write("\n");
+  term_write("\n");
+
+  // Modify the data stored at 1MB
+  *ptr = 0b101010101010;
+  // Recheck contents of page_table[1]
+  // Bits 5 and 6 were set - paging is working
+  for (int i = 31; i >= 0; i--) {
+    uint32_t x = *(uint32_t *)in & ((uint32_t)1 << i);
+    char c[2] = {'0', 0};
+    c[0] += !!x;
+    term_write(c);
+  }
+  term_write("\n");
+  // Check if the memory was actually modified
+  for (int i = 31; i >= 0; i--) {
+    uint32_t x = *ptr & ((uint32_t)1 << i);
+    char c[2] = {'0', 0};
+    c[0] += !!x;
+    term_write(c);
+  }
+  term_write("\n");
 }

--- a/src/paging.c
+++ b/src/paging.c
@@ -1,0 +1,74 @@
+/*
+ *   paging.c by MiniOs
+ */
+#include <stdint.h>
+
+// TODO (Britton): Explain all this
+typedef uint8_t PageFlags;
+
+typedef struct _PageDirectory PageDirectory;
+typedef struct _PageTable PageTable;
+typedef union _PageDirectoryEntry PageDirectoryEntry;
+typedef union _PageTableEntry PageTableEntry;
+
+union _PageDirectoryEntry {
+  PageFlags flags;
+  uint32_t entry;
+};
+
+union _PageTableEntry {
+  PageFlags flags;
+  uint32_t entry;
+};
+
+struct _PageDirectory {
+  PageDirectoryEntry entries[1024];
+};
+
+struct _PageTable {
+  PageTableEntry entries[1024];
+};
+
+#define PAGE_PRESENT ((PageFlags)1)
+#define PAGE_DIRTY ((PageFlags)(1 << 6))
+#define PAGE_ACCESSED ((PageFlags)(1 << 5))
+#define PAGE_ALLOW_USER_ACCESS ((PageFlags)(1 << 2))
+#define PAGE_ALLOW_WRITE ((PageFlags)(1 << 1))
+
+uint32_t get_page_directory_index(void *ptr) {
+  uint32_t mask = 0xFFC00000;
+  uint32_t result = (uint32_t)ptr & mask;
+  result >>= 22;
+  return result;
+}
+
+uint32_t get_page_table_index(void *ptr) {
+  uint32_t mask = 0x003FF000;
+  uint32_t result = (uint32_t)ptr & mask;
+  result >>= 12;
+  return result;
+}
+
+uint32_t get_page_offset(void *ptr) {
+  uint32_t mask = 0x00000FFF;
+  uint32_t result = (uint32_t)ptr & mask;
+  return result;
+}
+
+// Requires page_directory points to 4096 Bytes of memory for the page directory
+// And page_tables points to 1024 blocks of 4096 Bytes for the page tables
+// Fully maps the entire 4GiB virtual memory space to the physical memory
+// Virtual pointers should correspond exactly to the physical address
+void page_map_identity(PageDirectory *page_directory, PageTable *page_tables) {
+  PageFlags flags = PAGE_ALLOW_USER_ACCESS | PAGE_PRESENT | PAGE_ALLOW_WRITE;
+  for (uint32_t dir_index = 0; dir_index < 1024; dir_index++) {
+
+    page_directory->entries[dir_index].entry =
+        (uint32_t)(page_tables + dir_index) | flags;
+
+    for (uint32_t table_index = 0; table_index < 1024; table_index++) {
+      page_tables[dir_index].entries[table_index].entry =
+          (dir_index << 22) | (table_index << 12) | flags;
+    }
+  }
+}


### PR DESCRIPTION
Enable the dumbest form of paging - Identity paging. The entire 32-bit address space is paged in, with each virtual address corresponding exactly to the same physical address. 

The fact that this is working can be shown by the automatic updating of access bits in the page tables.