### PR TITLE
Fix CS jump bug and Document paging

### DIFF
--- a/src/boot.asm
+++ b/src/boot.asm
@@ -48,18 +48,26 @@ _start:
 ; TODO: Setup Paging here and any state that is needed before
 ; the kernel is loaded.
         ; Sets up gdt
+        ; Disable interrupts while setting up the GDT and paging
+        cli
+        ; First, set up the GDT descriptor,
+        ; which the CPU will use to find and interpret the GDT
         mov eax, gdt_descriptor
         mov ebx, gdt_base
+        ; The bottom 2 bytes of the GDT descriptor are the size in bytes of the GDT minus 1
         mov word [gdt_descriptor], 47
+        ; The top 4 bytes are the address of the GDT
         mov [gdt_descriptor + 2], ebx 
+        ; Push the address of the GDT to the stack for function call
         push ebx
         extern set_up_gdt
         call set_up_gdt
+        ; Once GDT is set up, lgdt with the GDT descriptor the set it
         lgdt [gdt_descriptor]
         ; TODO(Britton): Trying to reload cs fails on my machine,
         ; but in testing it was already set to 8.
         ; Figure out why it is not working to be sure we manually set it.
-        ; jmp 0x8:reload_cs
+        jmp 0x8:_start.reload_cs
         .reload_cs:
         mov ax, 0x10
         mov ds, ax
@@ -82,7 +90,9 @@ _start:
         mov eax, cr0
         or eax, 0x80000001
         mov cr0, eax
-
+        mov eax, cr0
+        ; re-enable interrupts
+        sti
 ; Enter the main kernel.
         extern kernel_main
         call kernel_main

--- a/src/gdt.c
+++ b/src/gdt.c
@@ -51,8 +51,8 @@ void set_up_gdt(uint8_t *target) {
   // Set Present, ring 0 privelege, non-system, executable, non-conforming,
   // readable, and not-accessed bit fields
   kernel_code_segment.access_byte = 0b10011010;
-  // Set page granularity and long-mode bit fields
-  kernel_code_segment.flags = 0b1010;
+  // Set page granularity and size bit fields
+  kernel_code_segment.flags = 0b1100;
 
   kernel_data_segment.limit = 0xFFFFF;
   // Set Present, ring 0 privelege, non-system, non-executable, non-conforming,
@@ -65,8 +65,8 @@ void set_up_gdt(uint8_t *target) {
   // Set Present, ring 3 privelege, non-system, executable, non-conforming,
   // readable, and not-accessed bit fields
   user_code_segment.access_byte = 0b11111010;
-  // Set page granularity and long-mode bit fields
-  user_code_segment.flags = 0b1010;
+  // Set page granularity and size bit fields
+  user_code_segment.flags = 0b1100;
 
   user_data_segment.limit = 0xFFFFF;
   // Set Present, ring 3 privelege, non-system, non-executable, non-conforming,

--- a/src/paging.c
+++ b/src/paging.c
@@ -1,16 +1,59 @@
 /*
  *   paging.c by MiniOs
+ *
+ *  NOTE(Britton): How paging works
+
+With paging enabled in 32-bit protected mode, virtual memory addressed with a
+2-layer table scheme
+
+The first layer table is the 'Page Directory' (PD) and there is only one
+The second layer tables are the 'Page Tables' (PT) and there are up to 1024 (1K)
+Both the PD and PT contain 1K 4-Byte long entries, making them 4K Bytes long in
+total: exactly 1 Page
+
+Entries in the PD and PT are identical in format,
+but a PD entry contains data pointing to an entire page table, while a PT entry
+poitns to a specific page Entries are formatted as follows: The bottom 12 bits
+(11-0) are reserved for bit flags and metadata about the PT/Page pointed to by
+the entry The top 20 bits (31-12) contain the 4K aligned PHYSICAL ADDRESS of the
+PT/Page pointed to
+
+Because there are only 20 Bits of address information available in a PD/PT
+entry, PDs and PTs must be 4K aligned
+
+With paging enabled, pointers are de-referenced as follows:
+Suppose a pointer points to X
+Bits 11-0 contain the offset of X's location in a page
+Some PT contains an entry pointing to the page where X is located.
+Bits 21-12 contain the index of the entry inside that PT which points to X's
+page The PD contains an entry pointing to the aforementioned PT Bits 31-22
+contain the index of the PD entry which points to X's PT
+
+Put concisely:
+(PD(i).addr->PT(j).addr + k)->X
  */
 #include <stdint.h>
 
 // TODO (Britton): Explain all this
 typedef uint8_t PageFlags;
 
+// These bit fields can be used to read/write data from a PD OR PT entry
+#define PAGE_PRESENT ((PageFlags)1)
+#define PAGE_DIRTY ((PageFlags)(1 << 6))
+#define PAGE_ACCESSED ((PageFlags)(1 << 5))
+#define PAGE_ALLOW_USER_ACCESS ((PageFlags)(1 << 2))
+#define PAGE_ALLOW_WRITE ((PageFlags)(1 << 1))
+
 typedef struct _PageDirectory PageDirectory;
 typedef struct _PageTable PageTable;
 typedef union _PageDirectoryEntry PageDirectoryEntry;
 typedef union _PageTableEntry PageTableEntry;
 
+// Both PD and PT entries are formatted identically,
+// But separating them may help the compiler to catch errors
+// flags field can be used to easily read/write metadata,
+// But since the address field is not byte-aligned,
+// There is no good way to make an 'addr' field
 union _PageDirectoryEntry {
   PageFlags flags;
   uint32_t entry;
@@ -21,6 +64,7 @@ union _PageTableEntry {
   uint32_t entry;
 };
 
+// Both PD and PT contain exactly 1K entries
 struct _PageDirectory {
   PageDirectoryEntry entries[1024];
 };
@@ -28,12 +72,6 @@ struct _PageDirectory {
 struct _PageTable {
   PageTableEntry entries[1024];
 };
-
-#define PAGE_PRESENT ((PageFlags)1)
-#define PAGE_DIRTY ((PageFlags)(1 << 6))
-#define PAGE_ACCESSED ((PageFlags)(1 << 5))
-#define PAGE_ALLOW_USER_ACCESS ((PageFlags)(1 << 2))
-#define PAGE_ALLOW_WRITE ((PageFlags)(1 << 1))
 
 uint32_t get_page_directory_index(void *ptr) {
   uint32_t mask = 0xFFC00000;


### PR DESCRIPTION
The CS jump bug was because I erroneously set the code segment flags to indicate long mode, this issue had been resolved.
Also add documentation for paging.