### PR TITLE
Working towards proper paging and Memory Management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vscode/
 cross/
 *.o
+*.a
 /src/build
 src/kernel.bin
 src/kernel.iso

--- a/src/boot.asm
+++ b/src/boot.asm
@@ -64,9 +64,6 @@ _start:
         call set_up_gdt
         ; Once GDT is set up, lgdt with the GDT descriptor the set it
         lgdt [gdt_descriptor]
-        ; TODO(Britton): Trying to reload cs fails on my machine,
-        ; but in testing it was already set to 8.
-        ; Figure out why it is not working to be sure we manually set it.
         jmp 0x8:_start.reload_cs
         .reload_cs:
         mov ax, 0x10

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -14,20 +14,7 @@ void kernel_main(BootInformation *boot_info) {
   void *loc = kernel_main;
   term_format("This is a format string hex: %x\n", &tmp);
   term_format("This is a format string hex: %x\n", &loc);
-
-  for (int i = 31; i >= 0; i--) {
-    uint32_t x = boot_info->flags & ((uint32_t)1 << i);
-    char c[2] = {'0', 0};
-    c[0] += !!x;
-    term_write(c);
-  }
-  term_write("\n");
-  for (int i = 31; i >= 0; i--) {
-    uint32_t x = boot_info->cmd_line & ((uint32_t)1 << i);
-    char c[2] = {'0', 0};
-    c[0] += !!x;
-    term_write(c);
-  }
-  term_write("\n");
   term_write((const char *)boot_info->cmd_line);
+  term_write("\n");
+
 }

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -1,7 +1,8 @@
 /** src/kernel.c */
+#include "multiboot.h"
 #include "term.h"
 
-void kernel_main() {
+void kernel_main(BootInformation *boot_info) {
   term_init();
   term_write("MiniOS Kernel Team #1\n");
   term_writeline("Testing writeline");
@@ -13,4 +14,20 @@ void kernel_main() {
   void *loc = kernel_main;
   term_format("This is a format string hex: %x\n", &tmp);
   term_format("This is a format string hex: %x\n", &loc);
+
+  for (int i = 31; i >= 0; i--) {
+    uint32_t x = boot_info->flags & ((uint32_t)1 << i);
+    char c[2] = {'0', 0};
+    c[0] += !!x;
+    term_write(c);
+  }
+  term_write("\n");
+  for (int i = 31; i >= 0; i--) {
+    uint32_t x = boot_info->cmd_line & ((uint32_t)1 << i);
+    char c[2] = {'0', 0};
+    c[0] += !!x;
+    term_write(c);
+  }
+  term_write("\n");
+  term_write((const char *)boot_info->cmd_line);
 }

--- a/src/multiboot.h
+++ b/src/multiboot.h
@@ -1,0 +1,42 @@
+#include <stdint.h>
+
+typedef struct _BootInformation BootInformation;
+struct _BootInformation {
+  uint32_t flags;
+
+  uint32_t mem_lower;
+  uint32_t mem_upper;
+
+  uint32_t boot_device;
+  uint32_t cmd_line;
+
+  uint32_t mods_count;
+  uint32_t *mods_addr;
+
+  uint32_t syms[4];
+
+  uint32_t mmap_length;
+  uint32_t *mmap_addr;
+
+  uint32_t drives_length;
+  uint32_t *drives_addr;
+
+  uint32_t *config_table;
+  uint32_t boot_loader_name;
+  uint32_t *apm_table;
+
+  uint32_t vbe_control_info;
+  uint32_t vbe_mode_info;
+  uint32_t vbe_mod;
+  uint32_t vbe_interface_seg;
+  uint32_t vbe_interface_off;
+  uint32_t vbe_interface_len;
+
+  uint32_t framebuffer_addr;
+  uint32_t framebuffer_pitch;
+  uint32_t framebuffer_width;
+  uint32_t framebuffer_height;
+  uint32_t framebuffer_bpp;
+  uint32_t framebuffer_type;
+  uint32_t color_info;
+};

--- a/src/multiboot.h
+++ b/src/multiboot.h
@@ -11,19 +11,19 @@ struct _BootInformation {
   uint32_t cmd_line;
 
   uint32_t mods_count;
-  uint32_t *mods_addr;
+  uint32_t mods_addr;
 
   uint32_t syms[4];
 
   uint32_t mmap_length;
-  uint32_t *mmap_addr;
+  uint32_t mmap_addr;
 
   uint32_t drives_length;
-  uint32_t *drives_addr;
+  uint32_t drives_addr;
 
-  uint32_t *config_table;
+  uint32_t config_table;
   uint32_t boot_loader_name;
-  uint32_t *apm_table;
+  uint32_t apm_table;
 
   uint32_t vbe_control_info;
   uint32_t vbe_mode_info;

--- a/src/multiboot.h
+++ b/src/multiboot.h
@@ -27,16 +27,16 @@ struct _BootInformation {
 
   uint32_t vbe_control_info;
   uint32_t vbe_mode_info;
-  uint32_t vbe_mod;
-  uint32_t vbe_interface_seg;
-  uint32_t vbe_interface_off;
-  uint32_t vbe_interface_len;
+  uint16_t vbe_mode;
+  uint16_t vbe_interface_seg;
+  uint16_t vbe_interface_off;
+  uint16_t vbe_interface_len;
 
-  uint32_t framebuffer_addr;
+  uint64_t framebuffer_addr;
   uint32_t framebuffer_pitch;
   uint32_t framebuffer_width;
   uint32_t framebuffer_height;
-  uint32_t framebuffer_bpp;
-  uint32_t framebuffer_type;
-  uint32_t color_info;
+  uint8_t framebuffer_bpp;
+  uint8_t framebuffer_type;
+  uint8_t color_info[6];
 };

--- a/src/paging.c
+++ b/src/paging.c
@@ -37,6 +37,10 @@ Put concisely:
 // TODO (Britton): Explain all this
 typedef uint8_t PageFlags;
 
+// This pointer should only be accessible by kernel code,
+// and only works after init_paging has been executed successfully
+#define PAGE_DIRECTORY_POINTER ((PageDirectory*)0xFFFFF000)
+
 // These bit fields can be used to read/write data from a PD OR PT entry
 #define PAGE_PRESENT ((PageFlags)1)
 #define PAGE_DIRTY ((PageFlags)(1 << 6))
@@ -44,10 +48,22 @@ typedef uint8_t PageFlags;
 #define PAGE_ALLOW_USER_ACCESS ((PageFlags)(1 << 2))
 #define PAGE_ALLOW_WRITE ((PageFlags)(1 << 1))
 
+#define Kilobytes(x) 1024 * x
+#define Megabytes(x) 1024 * Kilobytes(x)
+
 typedef struct _PageDirectory PageDirectory;
 typedef struct _PageTable PageTable;
 typedef union _PageDirectoryEntry PageDirectoryEntry;
 typedef union _PageTableEntry PageTableEntry;
+typedef struct _MemInfo MemInfo;
+
+// Global variable
+static uint32_t* pages[Megabytes(1)];
+static uint32_t page_alloc_index;
+
+// Global variable holds
+static uint32_t page_tables[Kilobytes(1)];
+static uint32_t pt_alloc_index;
 
 // Both PD and PT entries are formatted identically,
 // But separating them may help the compiler to catch errors
@@ -108,5 +124,85 @@ void page_map_identity(PageDirectory *page_directory, PageTable *page_tables) {
       page_tables[dir_index].entries[table_index].entry =
           (dir_index << 22) | (table_index << 12) | flags;
     }
+
   }
+}
+
+// Initializes paging to be used by the operating system
+// Paging should be disabled during initialization
+void init_paging(MemInfo* mem_info, PageDirectory* page_directory) {
+
+  // TODO(Britton): Use mem_info to identity page or otherwise smartly set up:
+  // mmaped I/O, kernel memory, etc
+
+  // Set The last page directory entry to point to the PD itself
+  // This way, virtual addr 0xFFFFF000 points to the base of the PD
+  // Now, 0xFFFFF000 + i can be used to edit PD entries after setting up paging 
+  page_directory->entries[1023].entry = page_directory;
+  page_directory->entries[1023].flags = PAGE_PRESENT | PAGE_ALLOW_WRITE;
+
+  // Fill 'pages' with all available physical addresses of pages
+  for (int32_t i = 0; i < (sizeof(pages) / sizeof(pages[0])); i++) {
+    
+    // TODO(Britton): Use mem_info to determine which pages are unavailable
+    // For the rest, put an entry in pages
+    pages[i] = 0;
+  }
+
+}
+
+/*
+* Begin paging API: should be usable by other parts of the kernel
+* TODO(Britton): Test all this
+*/
+
+// Returns the phys addr of one free page
+uint32_t* page_alloc() {
+  
+  // Check if there are any available pages
+  // Zero should never be an allocatable phys addr
+  // If page_alloc_index is greater than one megabyte,
+  // then it had an underflow and there are no pages left
+  if (pages[page_alloc_index] == 0 || page_alloc_index > Megabytes(1)) {
+    return 0;
+  }
+
+  uint32_t* result = pages[page_alloc_index];
+  pages[page_alloc_index] = 0;
+  page_alloc_index--;
+  return result;
+}
+
+// Adds a page back to the list of available pages
+// Takes the physical address of a page
+// TODO(Britton): Consider security
+void page_free(uint32_t* phys_addr) {
+  page_alloc_index++;
+  pages[page_alloc_index] = phys_addr;
+  
+}
+
+// Adds a new userland, writable page table to the page directory
+// Returns the PD entry index of the new PT
+uint32_t page_table_alloc() {
+
+  uint32_t* pt_addr = page_alloc();
+  uint32_t pt_index = page_tables[pt_alloc_index];
+  page_tables[pt_alloc_index] = 0;
+  pt_alloc_index--;
+  PAGE_DIRECTORY_POINTER->entries[pt_index].entry = pt_addr;
+  PAGE_DIRECTORY_POINTER->entries[pt_index].flags = PAGE_PRESENT | PAGE_ALLOW_USER_ACCESS | PAGE_ALLOW_WRITE;
+  return pt_index;
+
+}
+
+// Frees a PT from the PD
+void page_table_free(uint32_t pt_index) {
+
+  PageDirectoryEntry* entry_to_free = &(PAGE_DIRECTORY_POINTER->entries[pt_index]);
+  uint32_t* phys_addr = entry_to_free->entry & 0xFFFFF000;
+  page_free(phys_addr);
+  entry_to_free->entry = 0; 
+  pt_alloc_index++;
+  page_tables[pt_alloc_index] = pt_index;
 }


### PR DESCRIPTION
Here, I have started work on a primitive API for dynamically allocating pages. I do not have a way of testing the paging API without initializing the memory first, so the current implementation is purely theoretical. In order to properly initialize paging, we will need all the relevant information about the memory's current layout at boot. So, I have successfully acquired the BootInfo structure from grub, which will probably be critical in all stages of our OS's initialization.