### PR TITLE
Fix interrupts

### DIFF
--- a/src/boot.asm
+++ b/src/boot.asm
@@ -105,6 +105,8 @@ _start:
         ; re-enable interrupts
 
         ; setup IDT.
+        mov eax, isr
+        push eax
         extern setup_idt
         call setup_idt
 

--- a/src/interrupt.c
+++ b/src/interrupt.c
@@ -13,16 +13,17 @@ static void idt_set_descriptor(int idx, void *isr, uint8_t flags);
 
 extern void *isr;
 static idt_descriptor_t idt_desc;
-__attribute__((aligned(0x10))) static idt_gate_descriptor_t idt_table[MAX_IDT_ENTRIES];
+__attribute__((
+    aligned(0x10))) static idt_gate_descriptor_t idt_table[MAX_IDT_ENTRIES];
 
 void interrupt_handler() { term_write("Got an interrupt.\n"); }
 
-void setup_idt() {
+void setup_idt(void *isr_in) {
   idt_desc.offset = (uint32_t)&idt_table[0];
-  idt_desc.size = (uint16_t)(sizeof(idt_gate_descriptor_t) * (255));
+  idt_desc.size = (uint16_t)(sizeof(idt_gate_descriptor_t) * (255) - 1);
 
   for (int i = 0; i < MAX_IDT_ENTRIES; i++) {
-    idt_set_descriptor(i, isr, 0x8E);
+    idt_set_descriptor(i, isr_in, 0x8E);
   }
 
   __asm__ volatile("lidt %0" : : "m"(idt_desc));

--- a/src/interrupt.h
+++ b/src/interrupt.h
@@ -27,7 +27,7 @@ typedef struct idt_gate_descriptor {
   uint16_t offset_2; // 48..63
 } __attribute__((packed)) idt_gate_descriptor_t;
 
-void setup_idt();
+void setup_idt(void *isr_in);
 void interrupt_handler();
 
 #endif // INTERRUPT_H

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -13,4 +13,5 @@ void kernel_main() {
   void *loc = kernel_main;
   term_format("This is a format string hex: %x\n", &tmp);
   term_format("This is a format string hex: %x\n", &loc);
+  __asm__("int $0");
 }


### PR DESCRIPTION
For some reason, 
```
extern void* isr
```
 did not work. To fix this, I passed the address of isr as a parameter to the idt initializer, and interrupts now work. idt_desc.size should also be one less than the actual size of the idt in bytes.