### PR TITLE
kmalloc cleanup and fixes

### DIFF
--- a/src/interrupt.c
+++ b/src/interrupt.c
@@ -13,7 +13,8 @@ static void idt_set_descriptor(int idx, void *isr, uint8_t flags);
 
 extern void *isr;
 static idt_descriptor_t idt_desc;
-__attribute__((aligned(0x10))) static idt_gate_descriptor_t idt_table[MAX_IDT_ENTRIES];
+__attribute__((
+    aligned(0x10))) static idt_gate_descriptor_t idt_table[MAX_IDT_ENTRIES];
 
 void interrupt_handler() { term_write("Got an interrupt.\n"); }
 

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -22,7 +22,7 @@ void kernel_main() {
   term_write((const char *)boot_info->cmdline);
   term_write("\n");
 
-  #ifndef RELEASE
+#ifndef RELEASE
   test_all_functions();
-  #endif
+#endif
 }

--- a/src/kmalloc.h
+++ b/src/kmalloc.h
@@ -4,6 +4,6 @@
 #include <stddef.h>
 
 void *kmalloc(size_t size);
-void free(void *ptr);
+void kfree(void *ptr);
 
 #endif // KMALLOC_H


### PR DESCRIPTION
Just some cleanup of kmalloc and a fix that makes it return the pointer to the beginning of usable memory instead of the end.

I think make format jumbled a few tings too.