### PR TITLE
hardware timer.

### DIFF
--- a/src/include/interrupt/interrupt.h
+++ b/src/include/interrupt/interrupt.h
@@ -53,6 +53,5 @@ typedef struct idt_gate_descriptor {
 void setup_idt(void *isr_in, void *key_isr);
 void interrupt_handler(uint32_t int_num);
 void init_pic();
-void key_handler(uint32_t scan_code);
 
 #endif // INTERRUPT_INTERRUPT_H

--- a/src/include/interrupt/isr.h
+++ b/src/include/interrupt/isr.h
@@ -2,5 +2,6 @@
 #define INTERRUPT_ISR_H
 
 #define KEYBOARD_ISR 0x21
+#define TIMER_ISR 0x20
 
 #endif // INTERRUPT_ISR_H


### PR DESCRIPTION
I think we don't even really need to configure the timer that much; just handle the interrupt. Change involves simply handling the interrupt and removing the mask.

Each PIT interrupt can just increment a counter, that can call the scheduler on each iteration. The process state is stored in the interrupt routine (`push`)...

> As with a real-address mode interrupt return, the IRET instruction pops the return instruction pointer, return code segment selector, and EFLAGS image from the stack to the EIP, CS, and EFLAGS registers, respectively, and then resumes execution of the interrupted program or procedure. 

So the scheduler can dump another process to the values on the stack, we return back to the `timer_handler` and then when we iret we'll jump to the new process? Sounds like that would work.

Closes #28 