### PR TITLE
Fix "Invalid Opcode" Bug

### DIFF
--- a/src/include/interrupt/asm_tools.h
+++ b/src/include/interrupt/asm_tools.h
@@ -14,4 +14,18 @@ static inline uint8_t inb(uint16_t port) {
 
 static inline void io_wait() { outb(0x80, 0); }
 
+static inline uint32_t get_esp() {
+  uint32_t ret;
+  __asm__ volatile("mov %%esp, %d0" : "=a"(ret));
+  return ret;
+}
+static inline uint32_t get_eflags() {
+  uint32_t ret;
+  asm volatile ("pushf;\
+                                    pop %%eax;       \
+                                    mov %%eax, %0;"  \
+                                    :"=m" (ret)     \
+                                    ); 
+  return ret;
+}
 #endif

--- a/src/interrupt/isr_wrappers.asm
+++ b/src/interrupt/isr_wrappers.asm
@@ -18,6 +18,7 @@ isr%1:
         pop eax
         pop eax
         popad
+        mov esp, [esp - 20] ; popad does not restore the old stack pointer, so it must be manually restored here
         sti
         iret
 %endmacro

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -129,13 +129,12 @@ volatile void process_1() {
   while (1) {
     if (idx == 0) {
       //term_format("process 1: overflowed %x times\n", &overflows);
-  
+      
       overflows += 1;
     }
-    // TODO(Britton): An unknown bug causes this to result in an "Invalid Opcode" on some builds,
-    // Diagnose and fix
+    // NOTE(Britton): Checks if a message is available and prints it if there is one
     if(recv(&msg, 0)) {
-      term_format("RECV: %s", msg.data);
+     term_format("RECV: %s", msg.data);
     }
     idx = (idx + 1) & 0xFFFFFF;
   }


### PR DESCRIPTION
Process switching should now behave as intended, eliminating the "Invalid Opcode" bug that randomly appeared sometimes when running the OS. Fixed issues:
1. popad was not updating esp for the new process after a sched interrupt - esp is now updated manually.
2. eip, cs, and eflags needed to be pushed to the incoming process' stack for iret to work properly - they now are.
3. eip, cs, and eflags needed to be popped off the outgoing process' stack to restore its old state - they now are.
4. When admitting a new process, the "Interrupt Enable" bit in the process' starting eflags needed to be set - it now is.