### PR TITLE
Some String cleanup

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -8,7 +8,7 @@ INCLUDE=include/
 
 all: kernel.bin kernel.iso
 
-kernel.bin: boot.o kernel.o mem/libmem.a interrupt/libinterrupt.a vid/libvid.a test/libtest.a sched/libsched.a syscalls/libsyscalls.a ipc/libipc.a program/libprogram.a libk.a
+kernel.bin: boot.o kernel.o interrupt/libinterrupt.a vid/libvid.a test/libtest.a sched/libsched.a mem/libmem.a syscalls/libsyscalls.a ipc/libipc.a program/libprogram.a libk.a
 	$(CC) -T linker.ld -o $@ -ffreestanding -O2 -nostdlib $^ -lgcc $(DEF) -I$(INCLUDE)
 
 .PHONY: mem/libmem.a vid/libvid.a interrupt/libinterrupt.a test/libtest.a sched/libsched.a syscalls/libsyscalls.a ipc/libipc.a program/libprogram.a

--- a/src/program/echo.c
+++ b/src/program/echo.c
@@ -11,8 +11,21 @@ static void printf(char *buf) {
 }
 
 __attribute__((cdecl)) int echo_main(int argc, char **argv) {
-  for (int i = 1; i < argc; i++) {
+
+  for (uint32_t i = 1; i < argc; i++) {
     printf(argv[i]);
+
+    // NOTE/TODO(BP): Apparently saving the loop index with no less than 3
+    // volatile variables causes this to just work properly.
+    // Fix this properly
+    volatile uint32_t x;
+    volatile uint32_t y;
+    volatile uint32_t z;
+    x = i;
+    y = x;
+    z = y;
+    i = z;
+
   }
 
   return 0;

--- a/src/syscalls/syscalls.c
+++ b/src/syscalls/syscalls.c
@@ -43,7 +43,6 @@ uint32_t exit() {
   return swint(&syscall_info);
 }
 
-// TODO(BP): Implement argv because it is currently unused
 uint32_t spawn(uint32_t eip, uint32_t argc, char **argv) {
   spawn_args_t args = {0};
   args.eip = eip;

--- a/src/vid/term.c
+++ b/src/vid/term.c
@@ -95,13 +95,15 @@ void term_write_char(const char *c) {
     term_col = 1;
   }
 
+  // Increment the row if the character is a newline,
+  // and only actually print if it's not
   if (*c == '\n') {
     term_row++;
     term_col = 0;
+  } else {
+    size_t term_pos = term_row * VGA_WIDTH + term_col;
+    term_buf[term_pos] = vga_entry(*c, VGA_COLOR_WHITE);
   }
-
-  size_t term_pos = term_row * VGA_WIDTH + term_col;
-  term_buf[term_pos] = vga_entry(*c, VGA_COLOR_WHITE);
 }
 
 // Write out a string to the terminal buffer.


### PR DESCRIPTION
Fixes the unintended circle character from showing up at the beginning of lines, and (sort of) fixes the issue where a string longer than 32 bytes will cause echo to fail.

The fix to the second issue is not a real solution, its just some code that happens to magically make the compiler do what we originally intended, but does not address the underlying issue with our design that caused the bug in the first place.

I suspect that there is some way to cause interrupts to fail to restore esi properly, and making a "send" call inside the echo process with a string longer than 32 bytes happened trigger it.