### PR TITLE
spawn_bg and example program

### DIFF
--- a/src/include/program/program.h
+++ b/src/include/program/program.h
@@ -2,6 +2,7 @@
 #define PROGRAM_PROGRAM_H
 
 int echo_main(int argc, char **argv);
+int overflow_main(int argc, char **argv);
 int shell_main(int argc, char **argv);
 
 #endif // PROGRAM_PROGRAM_H

--- a/src/include/syscalls/syscalls.h
+++ b/src/include/syscalls/syscalls.h
@@ -13,7 +13,7 @@ typedef struct _syscall_info_t syscall_info_t;
 
 typedef struct _msg_t msg_t;
 
-enum _syscall_id_t {Sys_Send, Sys_Recv, Sys_Sleep, Sys_Exit, Sys_Spawn};
+enum _syscall_id_t {Sys_Send, Sys_Recv, Sys_Sleep, Sys_Exit, Sys_Spawn, Sys_Spawn_Bg};
 
 struct  _syscall_info_t {
     void* args;
@@ -31,5 +31,6 @@ uint32_t recv(msg_t* msg_dest, uint32_t comm_channel);
 uint32_t sleep(uint32_t ticks);
 uint32_t exit();
 uint32_t spawn(uint32_t eip, uint32_t argc, char** argv);
+uint32_t spawn_bg(uint32_t eip, uint32_t argc, char** argv);
 
 #endif

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -104,7 +104,9 @@ void kernel_main() {
   ipc_init();
 
   // TODO: What should these be?
-  fixed_alloc_init(0x4000000, 4096 * 512, 4096);
+  #define BLK_SIZE 1024*1024
+  #define BLK_COUNT 512
+  fixed_alloc_init(0x4000000, BLK_SIZE * BLK_COUNT, BLK_COUNT);
   bump_alloc_init( 0x4000000 + (4096 * 512) + 1, 4096 * 10);
 
   sched_admit((uint32_t)shell_main);

--- a/src/program/Makefile
+++ b/src/program/Makefile
@@ -2,7 +2,7 @@ CC=i686-elf-gcc
 AR=i686-elf-ar
 
 INCLUDE = -I../include/
-OBJECT = shell.o echo.o
+OBJECT = shell.o echo.o overflow.o
 TARGET = libprogram.a
 
 all: $(TARGET)

--- a/src/program/echo.c
+++ b/src/program/echo.c
@@ -25,7 +25,6 @@ __attribute__((cdecl)) int echo_main(int argc, char **argv) {
     y = x;
     z = y;
     i = z;
-
   }
 
   return 0;

--- a/src/program/overflow.c
+++ b/src/program/overflow.c
@@ -47,7 +47,7 @@ __attribute__((cdecl)) int overflow_main(int argc, char **argv) {
       printf("Overflowed\n");
       overflows += 1;
     }
-    idx = (idx + 1) & 0xFFFFFFF;
+    idx = (idx + 1) & 0x7FFFFFF;
   }
   return 0;
 }

--- a/src/program/overflow.c
+++ b/src/program/overflow.c
@@ -1,0 +1,53 @@
+#include "libc/string.h"
+#include "program/program.h"
+#include "syscalls/syscalls.h"
+#include "vid/term.h"
+
+static void printf(char *buf) {
+  msg_t msg = {0};
+  msg.data = buf;
+  msg.length = strlen(buf);
+  send(&msg, STDOUT);
+}
+
+uint32_t str_toint(char *s) {
+  uint32_t parsing = 1;
+  uint32_t i = 0;
+  uint32_t sum = 0;
+
+  while (parsing) {
+
+    uint8_t x = s[i];
+    x -= '0';
+    if (x > 9) {
+      parsing = 0;
+    } else {
+      sum *= 10;
+      sum += x;
+    }
+    i++;
+  }
+  return sum;
+}
+__attribute__((cdecl)) int overflow_main(int argc, char **argv) {
+
+  uint32_t def = 32;
+  uint32_t x = 0;
+  if (argc > 1) {
+    x = str_toint(argv[1]);
+  }
+  if (x == 0) {
+    x = def;
+  }
+  volatile uint32_t idx = 1;
+  uint32_t overflows = 0;
+  while (overflows < x) {
+
+    if (idx == 0) {
+      printf("Overflowed\n");
+      overflows += 1;
+    }
+    idx = (idx + 1) & 0xFFFFFFF;
+  }
+  return 0;
+}

--- a/src/program/shell.c
+++ b/src/program/shell.c
@@ -94,6 +94,13 @@ int shell_main(int argc, char **argv) {
           bump_free(NULL);
         }
 
+      } else if (strncmp("overflow", buf, 8) == 0) {
+        spawn_bg((uint32_t)&overflow_main, to_argc(buf), to_argv(buf));
+
+        // Free the ARGV arr + the individual strings.
+        for (int i = 0; i < to_argc(buf) + 1; i++) {
+          bump_free(NULL);
+        }
       } else {
         printf("Unrecognized command.");
       }

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -50,7 +50,7 @@ void sched_admit(uint32_t eip) {
       scheduler.process_table[i].state = PROCESS_READY;
 
       // Set the interrupt enable bit for the process
-      scheduler.process_table[i].register_ctx.EFLAGS = eflags;
+      scheduler.process_table[i].register_ctx.EFLAGS = eflags | INT_ENABLE_BIT;
       return;
     }
   }
@@ -95,7 +95,7 @@ void sched_admit_args(uint32_t eip, uint32_t argc, char **argv) {
       scheduler.process_table[i].state = PROCESS_READY;
 
       // Set the interrupt enable bit for the process
-      scheduler.process_table[i].register_ctx.EFLAGS = eflags;
+      scheduler.process_table[i].register_ctx.EFLAGS = eflags | INT_ENABLE_BIT;
       return;
     }
   }


### PR DESCRIPTION
Adds a spawn_bg syscall to show multiprogramming.
Also fixed an issue where the scheduler admits processes with interrupts disabled, and expands the block size of fixed_alloc.